### PR TITLE
Updates use of ibm-vpc-vsi submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data ibm_is_subnet vpc_subnet {
 }
 
 module "vsi-instance" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.3.0"
+  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.3.1"
 
   resource_group_id    = var.resource_group_id
   region               = var.region

--- a/module.yaml
+++ b/module.yaml
@@ -24,6 +24,16 @@ versions:
       refs:
         - source: github.com/cloud-native-toolkit/terraform-ibm-vpc-ssh
           version: ">= 1.0.0"
+    - id: cos_bucket
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-object-storage-bucket
+          version: ">= 0.0.1"
+      optional: true
+    - id: kms_key
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-kms-key
+          version: ">= 0.0.1"
+      optional: true
   variables:
     - name: vpc_name
       moduleRef:
@@ -53,3 +63,13 @@ versions:
       scope: global
     - name: tags
       scope: module
+    - name: flow_log_cos_bucket_name
+      moduleRef:
+        id: cos_bucket
+        output: bucket_name
+      optional: true
+    - name: kms_key_crn
+      moduleRef:
+        id: kms_key
+        output: crn
+      optional: true


### PR DESCRIPTION
- Bumps ibm-vpc-vsi to v1.3.1
- Adds cos_bucket and kms_key to module dependencies

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>