### PR TITLE
Updates to metadata

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -6,11 +6,17 @@ jobs:
   notify:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        repo:
+          - cloud-native-toolkit/ibm-garage-iteration-zero
+          - cloud-native-toolkit/garage-terraform-modules
+
     steps:
-      - name: Publish repository dispatch
-        uses: ibm-garage-cloud/action-repository-dispatch@main
+      - name: Repository dispatch ${{ matrix.repo }}
+        uses: cloud-native-toolkit/action-repository-dispatch@main
         with:
-          notifyRepo: ibm-garage-cloud/ibm-garage-iteration-zero
+          notifyRepo: ${{ matrix.repo }}
           eventType: released
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data ibm_is_subnet vpc_subnet {
 }
 
 module "vsi-instance" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.3.2"
+  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.4.0"
 
   resource_group_id    = var.resource_group_id
   region               = var.region
@@ -48,6 +48,7 @@ module "vsi-instance" {
   tags                 = local.tags
   security_group_rules = var.security_group_rules
   label                = var.label
+  allow_deprecated_image = var.allow_deprecated_image
 }
 
 resource ibm_is_security_group maintenance {

--- a/module.yaml
+++ b/module.yaml
@@ -71,3 +71,7 @@ versions:
         id: kms_key
         output: crn
       optional: true
+    - name: security_group_rules
+      scope: ignore
+    - name: allow_deprecated_image
+      scope: ignore

--- a/test/stages/stage2-bastion.tf
+++ b/test/stages/stage2-bastion.tf
@@ -8,4 +8,5 @@ module "bastion" {
   vpc_subnet_count    = module.subnets.count
   vpc_subnets         = module.subnets.subnets
   ssh_key_id          = module.vpcssh.id
+  allow_deprecated_image = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,9 @@ variable "security_group_rules" {
     }
   ]
 }
+
+variable "allow_deprecated_image" {
+  type        = bool
+  description = "Flag indicating that deprecated images should be allowed for use in the Virtual Server instance. If the value is `false` and the image is deprecated then the module will fail to provision"
+  default     = true
+}


### PR DESCRIPTION
- Sets security_group_rules variable to ignore in metadata
- Adds allow_deprected_image variable that passes through to bastion
- Sets allow_deprectated_image variable to ignore in metadata

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>