### PR TITLE
Updates security group rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ module "vsi-instance" {
   security_group_rules = var.security_group_rules
   label                = var.label
   allow_deprecated_image = var.allow_deprecated_image
+  base_security_group  = var.base_security_group
 }
 
 resource ibm_is_security_group maintenance {

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data ibm_is_subnet vpc_subnet {
 }
 
 module "vsi-instance" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.5.2"
+  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.6.0"
 
   resource_group_id    = var.resource_group_id
   region               = var.region

--- a/test/stages/stage1-gateways.tf
+++ b/test/stages/stage1-gateways.tf
@@ -5,6 +5,5 @@ module "gateways" {
   region            = var.region
   ibmcloud_api_key  = var.ibmcloud_api_key
   vpc_name          = module.vpc.name
-  vpc_id            = module.vpc.id
   subnet_count      = var.vpc_subnet_count
 }

--- a/test/stages/stage1-subnets.tf
+++ b/test/stages/stage1-subnets.tf
@@ -5,7 +5,6 @@ module "subnets" {
   region            = var.region
   ibmcloud_api_key  = var.ibmcloud_api_key
   vpc_name          = module.vpc.name
-  vpc_id            = module.vpc.id
   gateways          = module.gateways.gateways
   _count            = 1
   label             = "bastion"

--- a/variables.tf
+++ b/variables.tf
@@ -119,31 +119,19 @@ variable "security_group_rules" {
   description = "List of security group rules to set on the bastion security group in addition to the SSH rules"
   default = [
     {
-      name      = "http_outbound"
+      name      = "private-network"
       direction = "outbound"
-      remote    = "0.0.0.0/0"
-      tcp = {
-        port_min = 80
-        port_max = 80
-      }
+      remote    = "10.0.0.0/8"
     },
     {
-      name      = "https_outbound"
+      name      = "service-endpoints"
       direction = "outbound"
-      remote    = "0.0.0.0/0"
-      tcp = {
-        port_min = 443
-        port_max = 443
-      }
+      remote    = "161.26.0.0/16"
     },
     {
-      name      = "dns_outbound"
+      name      = "iaas-endpoints"
       direction = "outbound"
-      remote    = "0.0.0.0/0"
-      udp = {
-        port_min = 53
-        port_max = 53
-      }
+      remote    = "166.8.0.0/14"
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -141,3 +141,9 @@ variable "allow_deprecated_image" {
   description = "Flag indicating that deprecated images should be allowed for use in the Virtual Server instance. If the value is `false` and the image is deprecated then the module will fail to provision"
   default     = true
 }
+
+variable "base_security_group" {
+  type        = string
+  description = "The id of the base security group to use for the VSI instance. If not provided the default VPC security group will be used."
+  default     = null
+}


### PR DESCRIPTION
- Removes outbound rules for 0.0.0.0/0
- Restricts output rules to the private network, service endpoints, and iaas endpoints

Fixes #19

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>